### PR TITLE
Follow the XDG Base Dir specification, take 2.

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -260,7 +260,7 @@ The software inside the [AppImage] **MAY** integrate into the desktop environmen
 
 The software inside the [AppImage] **SHOULD NOT** attempt to do desktop integration if at least one of the following conditions are met:
 
-* A file `$XDG_DATA_HOME/appimagekit/no_desktopintegration` exists on the [target system] (with `$XDG_DATA_HOME` as defined in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html))
+* A file `${XDG_DATA_HOME:-$HOME/.local/share}/appimagekit/no_desktopintegration` exists on the [target system] ([XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html))
 * A file `/usr/share/appimagekit/no_desktopintegration` exists on the [target system]
 * A file `/etc/appimagekit/no_desktopintegration` exists on the [target system]
 * A process named `appimaged` is running on the system

--- a/draft.md
+++ b/draft.md
@@ -242,7 +242,7 @@ The software inside the [AppImage] **MAY** integrate into the desktop environmen
 
 The software inside the [AppImage] **SHOULD NOT** attempt to do desktop integration if at least one of the following conditions are met:
 
-* A file `$HOME/.local/share/appimagekit/no_desktopintegration` exists on the [target system]
+* A file `$XDG_DATA_HOME/appimagekit/no_desktopintegration` exists on the [target system] (with `$XDG_DATA_HOME` as defined in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html))
 * A file `/usr/share/appimagekit/no_desktopintegration` exists on the [target system]
 * A file `/etc/appimagekit/no_desktopintegration` exists on the [target system]
 * A process named `appimaged` is running on the system


### PR DESCRIPTION
I think that by adding `${XDG_DATA_HOME:-$HOME/.local/share}` and linking to the specification we are already indicating that when the variable is not set it should default to `$HOME/.local/share` and we don't need to add a new line explaining that, after all this is the AppImage spec.

But if you feel like the extra line explaining that is needed let me know.